### PR TITLE
Make it easier to track where a message came from

### DIFF
--- a/lib/Proc/Govern.pm
+++ b/lib/Proc/Govern.pm
@@ -298,7 +298,7 @@ sub govern_process {
         length($name) or $name = "prog";
     }
     defined($name) or die "Please specify name\n";
-    $name =~ /\A\w+\z/ or die "Invalid name, please use letters/numbers only\n";
+    $name =~ /\A\w+\z/ or die __PACKAGE__, ": Invalid name, please use letters/numbers only";
     $self->{name} = $name;
 
     if ($args{single_instance}) {


### PR DESCRIPTION
Today I received this message from code I was working on last week:

>     Invalid name, please use letters/numbers only

I had no idea where the message was from, and eventually I found it came from a bad usage of Proc::Govern (I had a '/' in the name argument). It would help if it were more explicit.